### PR TITLE
Add translation support for EditShippingZone navigation label

### DIFF
--- a/resources/lang/es/shippingzone.php
+++ b/resources/lang/es/shippingzone.php
@@ -28,6 +28,11 @@ return [
         'countries' => [
             'label' => 'Países',
         ],
+        'pages' => [
+            'edit' => [
+                'label' => 'Editar zona de Envío',
+            ],
+        ],
         'postcodes' => [
             'label' => 'Códigos Postales',
             'helper' => 'Lista cada código postal en una nueva línea. Soporta comodines como NW*',

--- a/src/Filament/Resources/ShippingZoneResource/Pages/EditShippingZone.php
+++ b/src/Filament/Resources/ShippingZoneResource/Pages/EditShippingZone.php
@@ -17,6 +17,11 @@ class EditShippingZone extends BaseEditRecord
         ];
     }
 
+    public static function getNavigationLabel(): string
+    {
+        return __('lunarpanel.shipping::shippingzone.pages.edit.label');
+    }
+
     protected function getRedirectUrl(): string
     {
         return $this->getResource()::getUrl('index');


### PR DESCRIPTION
 This PR adds the missing getNavigationLabel() method to EditShippingZone to maintain consistency with other pages in the module (ManageShippingRates and ManageShippingExclusions). Fixes issue #4 